### PR TITLE
Add our s3 path to font-awesome-rails

### DIFF
--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -26,6 +26,7 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
+  /**** CHANGED FONT PATH TO POINT TO OUR S3 BUCKET ON NEXT 2 LINES ****/
   src: url("//s3.amazonaws.com/cafewell-content/assets/fontawesome-webfont/fontawesome-webfont.eot");
   src: url("//s3.amazonaws.com/cafewell-content/assets/fontawesome-webfont/fontawesome-webfont.eot?#iefix")  format('embedded-opentype'), url("//s3.amazonaws.com/cafewell-content/assets/fontawesome-webfont/fontawesome-webfont.woff") format('woff'), url('//s3.amazonaws.com/cafewell-content/assets/fontawesome-webfont/fontawesome-webfont.ttf') format('truetype'), url('//s3.amazonaws.com/cafewell-content/assets/fontawesome-webfont/fontawesome-webfont.svg#fontawesomeregular')  format('svg');
   font-weight: normal;


### PR DESCRIPTION
Instead of creating a variable to change 2 lines of code, I thought it was just as easy to read by editing the 2 lines... so I changed the default paths in the font-awesome-rails gem to our s3 paths.

Because of how cloudfront caches http/https requests and making sure fonts come from our domain (or a referring domain), we sadly need to mod this path in order to make font awesome work with cafewell.
