### PR TITLE
Use the asset configuration to determine where to pull the fonts from

### DIFF
--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -30,7 +30,7 @@
   /**** CHANGED FONT PATH TO POINT TO OUR S3 BUCKET ON NEXT 2 LINES ****/
   /* To upgrade, increment number on version.rb, make new folder on s3 with the version number, add new fonts, change version on subsequent 2 lines, upgrade version in cafewell*/
   src: url("<%= asset_url("fontawesome-webfont.eot") %>");
-  src: url("<%= asset_url("fontawesome-webfont.eot?#iefix") %>")  format('embedded-opentype'), url("<%= asset_url("fontawesome-webfont.woff") %>") format('woff'), url("<%= asset_url("fontawesome-webfont.ttf") %>)") format('truetype'), url("<%= asset_url("fontawesome-webfont.svg#fontawesomeregular") %>")  format('svg');
+  src: url("<%= asset_url("fontawesome-webfont.eot?#iefix") %>")  format('embedded-opentype'), url("<%= asset_url("fontawesome-webfont.woff") %>") format('woff'), url("<%= asset_url("fontawesome-webfont.ttf") %>") format('truetype'), url("<%= asset_url("fontawesome-webfont.svg#fontawesomeregular") %>")  format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -29,8 +29,8 @@
   font-family: 'FontAwesome';
   /**** CHANGED FONT PATH TO POINT TO OUR S3 BUCKET ON NEXT 2 LINES ****/
   /* To upgrade, increment number on version.rb, make new folder on s3 with the version number, add new fonts, change version on subsequent 2 lines, upgrade version in cafewell*/
-  src: url("//s3.amazonaws.com/cafewell-content/assets/fontawesome/3.2.1.3.1/fontawesome-webfont.eot");
-  src: url("//s3.amazonaws.com/cafewell-content/assets/fontawesome/3.2.1.3.1/fontawesome-webfont.eot?#iefix")  format('embedded-opentype'), url("//s3.amazonaws.com/cafewell-content/assets/fontawesome/3.2.1.3.1/fontawesome-webfont.woff") format('woff'), url('//s3.amazonaws.com/cafewell-content/assets/fontawesome/3.2.1.3.1/fontawesome-webfont.ttf') format('truetype'), url('//s3.amazonaws.com/cafewell-content/assets/fontawesome/3.2.1.3.1/fontawesome-webfont.svg#fontawesomeregular')  format('svg');
+  src: url("<%= asset_url("fontawesome-webfont.eot") %>");
+  src: url("<%= asset_url("fontawesome-webfont.eot?#iefix") %>")  format('embedded-opentype'), url("<%= asset_url("fontawesome-webfont.woff") %>") format('woff'), url("<%= asset_url("fontawesome-webfont.ttf") %>)") format('truetype'), url("<%= asset_url("fontawesome-webfont.svg#fontawesomeregular") %>")  format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Remove hardcoded links to s3 buckets and replace with `asset_url` helpers that will read the Cafewell asset configuration

Please do not merge until https://github.com/welltok/cafewell/pull/5101 has been merged into Cafewell
